### PR TITLE
build reqExec on host

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -198,6 +198,7 @@ jobs:
     runtime:
       architecture: aarch64
       os: Ubuntu_16.04
+      container: false
     steps:
       - IN: aarch_64_Ubuntu_16_04_prep_repo
         switch: off


### PR DESCRIPTION
building aarch64 reqExec in container is failing for some reason. will debug this later. trying to build reqExec on host.